### PR TITLE
Fix argument specification in `pivot_wider()` and `pivot_longer()` calls

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -160,7 +160,7 @@
           wideNames <- wideColnames %>%
             select(all_of(names(wideID)), everything()) %>%
             unite(col = "new", !name, sep = "-_-_", na.rm = TRUE) %>%
-            pivot_wider(names_from = "name") %>%
+            pivot_wider(names_from = "name", values_from = "new") %>%
             unlist(use.names = FALSE)
           wideName <- paste0(names(wideID), collapse = "-_-_")
         } else {
@@ -203,7 +203,7 @@
           select(-all_of(varName)) %>%
           distinct() %>%
           unite(col = "new", !name, sep = "-_-_", na.rm = TRUE) %>%
-          pivot_wider(names_from = "name") %>%
+          pivot_wider(names_from = "name", values_from = "new") %>%
           unlist(use.names = FALSE)
 
         assertSetEqual(x = length(wideNames), y = tempDim[2])

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -397,8 +397,8 @@
         # make a subset table that contains numbers when possible
         subset <- subset %>%
           rownames_to_column() %>%
-          pivot_longer(-rowname, 'variable', 'value') %>%
-          pivot_wider(variable, rowname) %>%
+          pivot_longer(cols = -rowname, names_to = 'variable', values_to = 'value') %>%
+          pivot_wider(id_cols = variable, names_from = rowname, values_from = value) %>%
           select(-variable) %>%
           mutate(across(.cols = where(function(x) suppressWarnings(!anyNA(as.numeric(x)))), .fns = as.numeric))
 


### PR DESCRIPTION
We are preparing the release of tidyr 1.2.0, scheduled for mid January.

This package came up while running revdeps. There were a few small issues, one of which can be easily reproduced by installing the dev version of tidyr and running:

``` r
library(tabshiftr)
library(magrittr)

# use a function to find rows
input <- tabs2shift$messy_rows

schema <-
  setFilter(rows = .find(by = is.numeric, col = 1), invert = TRUE) %>%
  setIDVar(name = "territories", columns = 1) %>%
  setIDVar(name = "year", columns = 2) %>%
  setIDVar(name = "commodities", columns = 3) %>%
  setObsVar(name = "harvested", columns = 5) %>%
  setObsVar(name = "production", columns = 6)

validateSchema(schema = schema, input = input)
#> Error: Can't subset columns that don't exist.
#> x Column `name` doesn't exist.
```

There are a few distinct issues:

- `pivot_wider()` gained a new `id_expand` argument that comes right after the `id_cols` argument. One of your `pivot_wider()` calls didn't specify the arguments by name, so now your inputs are mapping to the wrong arguments
- A few `pivot_wider()` calls didn't specify `values_from`, which has a default of `value`, but there isn't a `value` column in your data frame. Instead there is a `new` column that should have been specified instead. The fact that this worked at all was a big bug on our end that has been fixed.
- A `pivot_longer()` call specified `'value'` as an input, but that mapped to `names_prefix` rather than `values_to`. By luck, this didn't break anything because `values_to` defaults to `"value"` too. I have updated that code to use named arguments.

We would greatly appreciate if you could merge this PR and submit your package to CRAN with the fix so we can release tidyr! You should be able to go ahead and release your package, as this fix doesn't require any dev tidyr features.

Thanks!